### PR TITLE
fix: preserve date when updating timesheet

### DIFF
--- a/src/modules/timesheets/timesheets.service.ts
+++ b/src/modules/timesheets/timesheets.service.ts
@@ -930,15 +930,15 @@ export class TimesheetsService {
     if (project_id !== undefined) updateData.project_id = project_id;
     if (task_id !== undefined) updateData.task_id = task_id;
 
-    // Only update date if it's provided, and convert to proper DateTime format
+    // Only update date if it's provided, and normalize to UTC start of day
     if (date) {
-      // Convert to start of day in ISO format to maintain date consistency
+      // Ensure date stays the same regardless of server timezone
       const dateObj = new Date(date);
-      dateObj.setHours(0, 0, 0, 0); // Set to start of day
-      updateData.date = dateObj.toISOString();
+      dateObj.setUTCHours(0, 0, 0, 0); // Set to start of day in UTC
+      updateData.date = dateObj; // Pass Date object directly to Prisma
       console.log('📅 Date processing:', {
         originalDate: date,
-        convertedDate: updateData.date,
+        normalizedDate: dateObj.toISOString(),
       });
     }
 


### PR DESCRIPTION
## Summary
- Normalize timesheet update dates to UTC to prevent entries from shifting days

## Testing
- `npm test` *(fails: Cannot find module 'src/modules/users/users.service')*
- `npm run lint` *(fails: ESLint flat config validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68a161ad5388833296e842183c8d1a1c